### PR TITLE
Changes 12/7/2018

### DIFF
--- a/__start_qcas_unittesting_script.py
+++ b/__start_qcas_unittesting_script.py
@@ -4,7 +4,9 @@ import glob
 import os
 import hashlib
 from datetime import datetime
-from test_datafiles import Preferences, CacheFile
+from test_datafiles import Preferences
+
+os.system('mode con: cols=150 lines=2500')
 
 # input: file to be hashed using sha256()
 # output: hexdigest of input file    
@@ -21,6 +23,7 @@ def dohash_sha256(fname, chunksize=8192):
     return m.hexdigest()
 
 my_preferences = Preferences()
+
 if my_preferences.will_skip_lengthy_validations():
     print("\n ==== QCAS Unit Testing started on: " + str(datetime.now()) + " by: " + getpass.getuser() + " SKIPPING LENGTHY VALIDATIONS! ====\n")
 else: 

--- a/preferences.dat
+++ b/preferences.dat
@@ -1,0 +1,27 @@
+{
+    "MSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v01.msl",
+    "PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v03.psl",
+    "TSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v02.tsl",
+    "epsig_log_file": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\log\\epsig.log",
+    "mid_list": [
+        "00",
+        "01",
+        "05",
+        "07",
+        "09",
+        "12",
+        "17"
+    ],
+    "nextMonth_MSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v01.msl",
+    "nextMonth_PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v01.psl",
+    "path_to_binimage": "\\\\Justice.qld.gov.au\\Data\\OLGR-TECHSERV\\BINIMAGE",
+    "previous_TSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_06_v03.tsl",
+    "write_new_games_to_file": "new_games.json",
+    "valid_bin_types": [
+        "BLNK",
+        "PS32",
+        "SHA1"
+    ],
+    "skip_lengthy_validations": "true",
+    "percent_changed_acceptable" : 0.10
+}

--- a/test_chk01_checklist.py
+++ b/test_chk01_checklist.py
@@ -219,7 +219,8 @@ class test_chk01_checklist(QCASTestClient):
                     tmpStr = str(localhash).lstrip('0X').zfill(40) # forces 40 characters with starting 0 characters. 
                     tmpStr = str(localhash).lstrip('0x').zfill(40)
                     localhash = self.getQCAS_Expected_output(tmpStr).upper() # format it
-                    
+                    print("\nHash Generated for: " + os.path.basename(blnk_file) + " = [" + localhash + "]")
+
                     psl_entries_list = list() 
                     # Compare Hash with PSL Entry
                     if msl == self.nextMonth_MSLfile: 
@@ -284,6 +285,7 @@ class test_chk01_checklist(QCASTestClient):
                     tmpStr = str(localhash).lstrip('0X').zfill(40) # forces 40 characters with starting 0 characters. 
                     tmpStr = str(localhash).lstrip('0x').zfill(40)
                     localhash = self.getQCAS_Expected_output(tmpStr).upper() # format it
+                    print("\nHash Generated for: " + os.path.basename(blnk_file) + " = [" + localhash + "]")
                     
                     psl_entries_list = list() 
                     # Compare Hash with PSL Entry

--- a/test_psl_file_content.py
+++ b/test_psl_file_content.py
@@ -1,4 +1,5 @@
 import os
+import unittest
 from test_datafiles import QCASTestClient, PSLfile
 
 class test_PSLfile_content(QCASTestClient): 
@@ -6,21 +7,31 @@ class test_PSLfile_content(QCASTestClient):
     def test_psl_size_is_reasonable(self): 
         psl_files = [self.PSLfile, self.nextMonth_PSLfile] 
         for psl_file in psl_files: 
-            size_in_bytes = os.stat(psl_file)
+            size_in_bytes = os.stat(psl_file).st_size # filesize
             
             # Verify that the size of the PSL files is reasonable. 
             # (The size range generally grows a few Kilobytes per run) and 
             # is approximately 1055KB as at July 2013.
-            self.assertTrue(size_in_bytes.st_size > 1055000)
+            self.assertTrue(size_in_bytes > 1055000)
     
+    # @unittest.expectedFailure
     def test_psl_size_reduction(self):
         psl_files = [self.PSLfile, self.nextMonth_PSLfile] 
 
-        PSLfile_size_in_bytes = os.stat(self.PSLfile)
-        nextMonth_PSLfile_size_in_bytes = os.stat(self.nextMonth_PSLfile)
+        PSLfile_size_in_bytes = os.stat(self.PSLfile).st_size # filesize
+        nextMonth_PSLfile_size_in_bytes = os.stat(self.nextMonth_PSLfile).st_size # filesize
+        
+        # +/-10% of the current PSL size is acceptable. 
+        acceptable_size = float(PSLfile_size_in_bytes) * self.my_preferences.percent_changed_acceptable # 0.10
+        
+        warning_string_upper = "expected: " + str(float(PSLfile_size_in_bytes) + acceptable_size) + " bytes, calculated: " + str(nextMonth_PSLfile_size_in_bytes)
+        warning_string_lower = "expected: " + str(float(PSLfile_size_in_bytes) - acceptable_size) + " bytes, calculated: " + str(nextMonth_PSLfile_size_in_bytes)
+        
+        self.assertTrue(nextMonth_PSLfile_size_in_bytes < (float(PSLfile_size_in_bytes) + acceptable_size), warning_string_upper) 
+        self.assertTrue(nextMonth_PSLfile_size_in_bytes > (float(PSLfile_size_in_bytes) - acceptable_size), warning_string_lower)  
         
         # VS request: 10.	The reduction of size of the PSL file from its previous version is not highlighted / checked.
-        self.assertTrue(nextMonth_PSLfile_size_in_bytes > PSLfile_size_in_bytes) 
+        #self.assertTrue(nextMonth_PSLfile_size_in_bytes > PSLfile_size_in_bytes) 
     
     def test_PSL_content_can_be_parsed(self):
         pslfile_list = [self.PSLfile, self.nextMonth_PSLfile] # test both months


### PR DESCRIPTION
- Changed CMD window to bet 150 width, 2500 lines
- Included additional Hash Generated Printouts
- Added percent_changed_acceptable as a configurable parameter for checking if next month's PSL has increased by this amount.  
- VGT references to QGS in paths
- Fixed issues with epsig log verifications
