### PR TITLE
Changes 20-08-2018

### DIFF
--- a/preferences.dat
+++ b/preferences.dat
@@ -1,7 +1,7 @@
 {
-    "MSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v01.msl",
-    "PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v04.psl",
-    "TSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v03.tsl",
+    "MSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v01.msl",
+    "PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v04.psl",
+    "TSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v02.tsl",
     "epsig_log_file": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\log\\epsig.log",
     "mid_list": [
         "00",
@@ -12,10 +12,10 @@
         "12",
         "17"
     ],
-    "nextMonth_MSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v01.msl",
-    "nextMonth_PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v02.psl",
+    "nextMonth_MSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_09_v01.msl",
+    "nextMonth_PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_09_v02.psl",
     "path_to_binimage": "\\\\Justice.qld.gov.au\\Data\\OLGR-TECHSERV\\BINIMAGE",
-    "previous_TSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v02.tsl",
+    "previous_TSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\Backup Qcas\\qcas_2018_08_v01.tsl",
     "write_new_games_to_file": "new_games.json",
     "valid_bin_types": [
         "BLNK",
@@ -24,5 +24,5 @@
     ],
     "skip_lengthy_validations": "true",
     "percent_changed_acceptable" : 0.10,
-    "verbose_mode" : "false"
+    "verbose_mode" : "true"
 }

--- a/test_chk01_checklist.py
+++ b/test_chk01_checklist.py
@@ -10,7 +10,7 @@ from test_datafiles import QCASTestClient, PSLfile, PSLEntry_OneHash, TSLfile, M
 def skipping_length_tests(): 
     my_preferences = Preferences()
     return my_preferences.will_skip_lengthy_validations()
-
+   
 class test_chk01_checklist(QCASTestClient):      
     
     def write_to_file(self, fname, data):

--- a/test_epsig_log_files.py
+++ b/test_epsig_log_files.py
@@ -1,9 +1,12 @@
 import os
 import csv
-from test_datafiles import QCASTestClient, PSLfile, TSLfile, MSLfile
+import unittest
+from test_datafiles import QCASTestClient, PSLfile, TSLfile, MSLfile, Preferences
 from datetime import datetime, date
 
 NUMBER_OF_VALID_DAYS_SINCE_START_OF_LOG = 60
+NUMBER_OF_VALID_DAYS_SINCE_END_OF_LOG = 60
+
 VALID_EPSIG_VERSION = '3.5'
 #LOG_FILE = "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\log\\epsig.log"
 #LOG_FILE = "C:\\Users\\aceretjr\\Documents\\dev\\qcas-Datafiles-Unittest\\logs\\epsig.log"
@@ -43,6 +46,36 @@ class EpsigLogFile():
             }
 
         return self.epsig_log_entry_str.strip()
+
+def last_four_logs_success_exit(): 
+    today = datetime.now()
+    my_preferences = Preferences()
+    last_four_logs_ok = False
+    
+    with open(my_preferences.epsig_log_file, 'r') as file: 
+        epsig_log = file.read()
+        paragraphs = epsig_log.split('\n\n')
+        
+        log_blocks = list() 
+        
+        # Get Last 4 paragraphs (end of file) with EXIT_SUCCESS
+        for i in list(range(1,5)): 
+            data = paragraphs[len(paragraphs)-i].split('\n') 
+            data = list(filter(None, data)) # remove empty lists    
+            log_entry = EpsigLogFile(data)
+            log_blocks.append(log_entry)
+            
+        current_month_list = list() 
+        next_month_list = list() 
+        
+        for log_file in log_blocks:
+            if not log_file.is_complete(): 
+                last_four_logs_ok = False
+                break
+            else: 
+                last_four_logs_ok = True
+                    
+    return last_four_logs_ok
         
 class test_epsig_log_files(QCASTestClient):
 
@@ -50,11 +83,12 @@ class test_epsig_log_files(QCASTestClient):
         psl_file = s.split(' ')[5]
         self.assertTrue(psl_file.endswith(".psl")) 
         return psl_file
-
+        
     def test_Read_Epsig_log_file_from_disk(self):
         self.assertTrue(os.path.isfile(self.my_preferences.epsig_log_file), 
         	msg=self.my_preferences.epsig_log_file + ": File not found")
-            
+        
+    @unittest.skipIf(last_four_logs_success_exit() == False, "Skipping PSL version inc tests: Last 4 entries did not complete!")        
     def test_epsig_log_file_last_four_entries_are_valid_for_psl_versions(self): 
         # EPSIG.EXE Version 3.5 Copyright The State of Queensland 1999-2015
         # Started at   Fri Oct 06 08:41:37 2017
@@ -131,6 +165,8 @@ class test_epsig_log_files(QCASTestClient):
             self.assertTrue(int(next_month_list[1][14:16]) == (int(next_month_list[0][14:16]) + 1), "Second PSL version is not incremented by 1")
     
     def test_epsig_log_file_last_two_entries_command_str_is_valid(self): 
+        today = datetime.now()
+        
         with open(self.my_preferences.epsig_log_file, 'r') as file: 
             epsig_log = file.read()
             paragraphs = epsig_log.split('\n\n')
@@ -143,7 +179,33 @@ class test_epsig_log_files(QCASTestClient):
                 data = list(filter(None, log)) # remove empty lists    
                 epsig_entry = EpsigLogFile(data)
                 
-                self.assertTrue(epsig_entry.is_complete())
+                # Verify EPSIG version number. 
+                self.assertEqual(epsig_entry.version_number, VALID_EPSIG_VERSION, 
+                    msg="EPSIG version not equal to: " + VALID_EPSIG_VERSION)
                 
+                # The dates and start and finish time of processing appear reasonable
+                # Valid Start Date: Assume within 7 days from current date
+                time_stamp_start_obj = datetime.strptime(epsig_entry.time_stamp_start_str[13:], "%a %b %d %H:%M:%S %Y")
+                time_delta = today - time_stamp_start_obj
+                
+                self.assertTrue(time_delta.days < NUMBER_OF_VALID_DAYS_SINCE_START_OF_LOG, 
+                    msg="Number of days since last epsig log started is greater than " 
+                        + str(NUMBER_OF_VALID_DAYS_SINCE_START_OF_LOG)) # less than NUMBER_OF_VALID_DAYS_SINCE_START_OF_LOG days
+                    
+                if epsig_entry.is_complete(): 
+                    time_stamp_end_obj = datetime.strptime(epsig_entry.time_stamp_end[13:], "%a %b %d %H:%M:%S %Y")
+                    time_delta_end = today - time_stamp_end_obj
+                    
+                    self.assertTrue(time_delta_end.days < NUMBER_OF_VALID_DAYS_SINCE_END_OF_LOG, 
+                        msg="Number of days since last epsig log ended is greater than " 
+                            + str(NUMBER_OF_VALID_DAYS_SINCE_END_OF_LOG))
+
+                    
+                    # The latest run Epsig error file is correct.(Ref WI01)      
+                    self.assertEqual(epsig_entry.footer_status, " with EXIT_SUCCESS", 
+                            msg="Epsig Log file did not end with 'EXIT_SUCCESS")
+                
+                self.assertTrue(epsig_entry.is_complete())
+
                 # Ensure that the parameters of the epsig.exe call appear correct, ...         
                 self.verify_epsig_command_used(epsig_entry.command_str)

--- a/test_file_name_format.py
+++ b/test_file_name_format.py
@@ -1,6 +1,6 @@
 import os
+import unittest
 from test_datafiles import QCASTestClient, PSLfile
-from tkinter import filedialog
 
 class test_file_name_format(QCASTestClient): 
 
@@ -43,7 +43,8 @@ class test_file_name_format(QCASTestClient):
     def test_PSLfile_ends_with_PSL(self):
         assert(str(self.PSLfile).upper().endswith("PSL"))
         assert(str(self.nextMonth_PSLfile).upper().endswith("PSL"))
-
+    
+    ## @unittest.skip("Skipping PSL version inc tests")        
     def test_PSL_file_version_increment(self):
         psl_version = self.get_filename_version(self.PSLfile)
         next_month_psl_version = self.get_filename_version(self.nextMonth_PSLfile)
@@ -54,47 +55,47 @@ class test_file_name_format(QCASTestClient):
         # "PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_07_v04.psl",
         # "nextMonth_PSLfile": "G:\\OLGR-TECHSERV\\MISC\\BINIMAGE\\qcas\\qcas_2018_08_v02.psl",
 
-        
         # if month is the same, version should increment
+        # This is the only thing we can reliably test. 
         if current_month == next_month:
             # next month version should always be greater than current month
             self.assertTrue(int(next_month_psl_version) > int(psl_version))
-        else:
-            # Months are not equal, therefore versions can be anything
-            # without knowing what the previous current month file was 
-            # can't assume that the next month psl version is equal to 1.
+        # else:
+            # # Months are not equal, therefore versions can be anything
+            # # without knowing what the previous current month file was 
+            # # can't assume that the next month psl version is equal to 1.
 
-            # Assume the previous PSL file and previous nextMonthPSL file
-            previous_PSLfile = "qcas_" + self.get_filename_year(self.PSLfile) + "_" + current_month + "_v" + self.format_twoDigit(int(psl_version) - 1) + ".psl"
-            previous_nextMonth_PSLfile = "qcas_" + self.get_filename_year(self.nextMonth_PSLfile) + "_" + next_month + "_v" + self.format_twoDigit(int(next_month_psl_version) - 1) + ".psl"
-            path = os.path.dirname(self.PSLfile)
-            previous_PSLfile = os.path.join(path, previous_PSLfile)
-            previous_nextMonth_PSLfile = os.path.join(path, previous_nextMonth_PSLfile)
+            # # Assume the previous PSL file and previous nextMonthPSL file
+            # previous_PSLfile = "qcas_" + self.get_filename_year(self.PSLfile) + "_" + current_month + "_v" + self.format_twoDigit(int(psl_version) - 1) + ".psl"
+            # previous_nextMonth_PSLfile = "qcas_" + self.get_filename_year(self.nextMonth_PSLfile) + "_" + next_month + "_v" + self.format_twoDigit(int(next_month_psl_version) - 1) + ".psl"
+            # path = os.path.dirname(self.PSLfile)
+            # previous_PSLfile = os.path.join(path, previous_PSLfile)
+            # previous_nextMonth_PSLfile = os.path.join(path, previous_nextMonth_PSLfile)
             
             # test these files exists, if they exist then the format of the files they were derived from (PSLfile and nextMonth PSLfile) is correct
-            self.assertTrue(os.path.isfile(previous_PSLfile))
-            self.assertTrue(os.path.isfile(previous_nextMonth_PSLfile))
+            # self.assertTrue(os.path.isfile(previous_PSLfile))
+            # self.assertTrue(os.path.isfile(previous_nextMonth_PSLfile))
             
-            # Additional Validations for the assumed PSL files: 
-            # Parse the PSL files
-            pslfile_list = [previous_PSLfile, previous_nextMonth_PSLfile] # test both months
+            # # Additional Validations for the assumed PSL files: 
+            # # Parse the PSL files
+            # pslfile_list = [previous_PSLfile, previous_nextMonth_PSLfile] # test both months
 
-            for pslfile in pslfile_list: 
-            # Check for PSL File Format by Instantiating an object of PSL type
-                game_list = self.check_file_format(pslfile, 'PSL')
+            # for pslfile in pslfile_list: 
+            # # Check for PSL File Format by Instantiating an object of PSL type
+                # game_list = self.check_file_format(pslfile, 'PSL')
 
-                for game in game_list:
-                    # Check for PSL manufacturer field
-                    self.assertTrue(self.check_manufacturer(game.manufacturer))
+                # for game in game_list:
+                    # # Check for PSL manufacturer field
+                    # self.assertTrue(self.check_manufacturer(game.manufacturer))
 
-                    # Check for PSL Game name field
-                    self.assertTrue(self.check_game_name(game.game_name))
+                    # # Check for PSL Game name field
+                    # self.assertTrue(self.check_game_name(game.game_name))
 
-                    # Check for PSL year field
-                    self.assertTrue(self.check_year_field(game.year))
+                    # # Check for PSL year field
+                    # self.assertTrue(self.check_year_field(game.year))
                     
-                    # Check for PSL month field
-                    self.assertTrue(self.check_month_field(game.month))
+                    # # Check for PSL month field
+                    # self.assertTrue(self.check_month_field(game.month))
             
         #else: 
         #    self.assertEqual(int(next_month_psl_version), 1) # New Month, version is v1                           


### PR DESCRIPTION
I have updated the script relating to testing the test_epsig_log_files.py with a test condition. 
Now it will first verify if the last 4 log entries have successfully exited (with EXIT_SUCCESS), before attempting to perform unit tests related to PSL versioning. 

I have also changed the test_file_name_format.py for PSL file version increment testing and reduced complexity to checking only if the months are equal. Then the version number is expected to be incremented by one, if the PSL months are not equal then I can’t reliably tell what version number it should be (that’s were reviewing the log files come in).