### PR TITLE
Addressed Games Removed from PSL files

### DIFF
--- a/preferences.dat
+++ b/preferences.dat
@@ -1,7 +1,7 @@
 {
-    "MSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2018_11_v01.msl",
-    "PSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2018_11_v04.psl",
-    "TSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2018_11_v02.tsl",
+    "MSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_02_v01.msl",
+    "PSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_02_v03.psl",
+    "TSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_02_v01.tsl",
     "epsig_log_file": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/log/epsig.log",
     "mid_list": [
         "00",
@@ -12,14 +12,25 @@
         "12",
         "17"
     ],
-    "nextMonth_MSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2018_12_v01.msl",
-    "nextMonth_PSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2018_12_v02.psl",
+    "nextMonth_MSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_03_v01.msl",
+    "nextMonth_PSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_03_v01.psl",
     "number_of_random_games": 4,
     "one_month_mode": "FALSE",
     "path_to_binimage": "//Justice.qld.gov.au/Data/OLGR-TECHSERV/BINIMAGE",
     "percent_changed_acceptable": 0.1,
-    "previous_TSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2018_11_v01.tsl",
+    "previousMonth_PSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_02_v02.psl",
+    "previous_TSLfile": "G:/OLGR-TECHSERV/MISC/BINIMAGE/qcas/qcas_2019_01_v02.tsl",
     "skip_lengthy_validations": "TRUE",
+    "unittests": [
+        "CHK01 Intensive validations",
+        "CHK01 game removals",
+        "Datafile Filename format tests",
+        "MSL File Content Tests: ",
+        "PSL File Content Tests: ",
+        "TSL File Content Tests: ",
+        "epsig log file content tests",
+        "CHK01 Validations"
+    ],
     "valid_bin_types": [
         "BLNK",
         "PS32",

--- a/test_chk01_checklist_game_removals.py
+++ b/test_chk01_checklist_game_removals.py
@@ -86,10 +86,16 @@ class test_chk01_checklist_game_removals(QCASTestClient):
         if self.verbose_mode: 
             logging.getLogger().debug("Expected PSL differences: " + str(len(psl_ssan_difference)))
         
-        err_msg = "Not the same games being added/removed from TSL vs PSL, check you selected the correct previous PSL file: " + previousMonth_PSLfile
-        xor_difference =  psl_ssan_difference ^ set(tsl_ssan_list)                # psl_ssan_difference.symmetric_difference(set(tsl_ssan_list))# 
+        xor_difference =  psl_ssan_difference ^ set(tsl_ssan_list) # psl_ssan_difference.symmetric_difference(set(tsl_ssan_list))
+        # psl_ssan_difference ^ set(tsl_ssan_list)
+        
         if len(xor_difference) != 0: 
-            logging.getLogger().debug("Unexpected SSAN differences: " + str(xor_difference))
-            
-        self.assertTrue(len(xor_difference) == 0, msg=err_msg) # bitwise XOR, must be zero fcr matching
+            logging.getLogger().debug("Unexpected SSAN differences: " + str(xor_difference)) # display differences in log file
+
+        err_msg = "Not the same games being added/removed from TSL vs PSL. \nCheck you selected the correct previous PSL files: " \
+            + previousMonth_PSLfile + " vs " + PSLfile \
+            + " \nCheck you selected the correct TSL files: "  + previous_TSLfile + " vs " + currentTSLfile \
+            + " \nSSAN differences: " + str(xor_difference)
+        
+        self.assertTrue(len(xor_difference) == 0, msg=err_msg) # bitwise XOR, must be zero for matching
         

--- a/test_chk01_checklist_game_removals.py
+++ b/test_chk01_checklist_game_removals.py
@@ -28,15 +28,14 @@ class test_chk01_checklist_game_removals(QCASTestClient):
 
     def getTSLDifference_List(self, previous_TSLfile, currentTSLfile): 
         tsl_difference = set()
-        verbose_mode = self.my_preferences.data['verbose_mode'].upper() == "TRUE"
 
         with open(previous_TSLfile, 'r') as file1: 
             with open(currentTSLfile, 'r') as file2: 
-                tsl_difference = set(file2).difference(file1)
+                tsl_difference = set(file2).symmetric_difference(set(file1))
                 
         # tsl_difference should now contain added and removed games. 
-        if verbose_mode: 
-            logging.getLogger().debug("Expected TSL differences: " + str(len(tsl_difference))) 
+        if self.verbose_mode: 
+            logging.getLogger().debug("Expected TSL differences: " + str(len(tsl_difference)))   
         
         # build a list of SSAN from TSL objects for comparison
         tsl_ssan_list = list() 
@@ -67,16 +66,13 @@ class test_chk01_checklist_game_removals(QCASTestClient):
         
         return psl_ssan_difference
         
-    # @unittest.skip("TODO: Not yet implemented")
     def test_Games_removed_from_PSL_files(self): 
         previous_TSLfile = self.my_preferences.data['previous_TSLfile']
         currentTSLfile = self.my_preferences.data['TSLfile']        
         PSLfile = self.my_preferences.data['PSLfile']
         previousMonth_PSLfile = self.my_preferences.data['previousMonth_PSLfile']
-        
-        verbose_mode = self.my_preferences.data['verbose_mode'].upper() == "TRUE"
-        
-        if verbose_mode: 
+                
+        if self.verbose_mode: 
             logging.getLogger().info("Testing Games removed from TSL files matches PSL files")
         
         # the verify script can perform checks comparing the differences in the entries of old and new TSL file which 
@@ -87,8 +83,13 @@ class test_chk01_checklist_game_removals(QCASTestClient):
         # We will require previous Month's PSL file.        
         psl_ssan_difference = self.getPSLDifference_List(PSLfile, previousMonth_PSLfile)
 
-        if verbose_mode: 
+        if self.verbose_mode: 
             logging.getLogger().debug("Expected PSL differences: " + str(len(psl_ssan_difference)))
         
         err_msg = "Not the same games being added/removed from TSL vs PSL, check you selected the correct previous PSL file: " + previousMonth_PSLfile
-        self.assertTrue(len(psl_ssan_difference ^ set(tsl_ssan_list)) == 0, msg=err_msg) # bitwise XOR, must be zero fcr matching
+        xor_difference =  psl_ssan_difference ^ set(tsl_ssan_list)                # psl_ssan_difference.symmetric_difference(set(tsl_ssan_list))# 
+        if len(xor_difference) != 0: 
+            logging.getLogger().debug("Unexpected SSAN differences: " + str(xor_difference))
+            
+        self.assertTrue(len(xor_difference) == 0, msg=err_msg) # bitwise XOR, must be zero fcr matching
+        


### PR DESCRIPTION
Bug fix - issue related to expected TSL differences were only highlighting added games, and not the complete difference which should have included any removed game. Upon comparing this to an expected PSL SSAN list, the PSL list contained additional changes which resulted to having an assert raised.